### PR TITLE
hide volume backend name from users

### DIFF
--- a/environment_config.yaml
+++ b/environment_config.yaml
@@ -17,12 +17,6 @@ attributes:
     description: 'The password for the specified SSH account.'
     weight: 45
     type: "password"
-  volume_backend_name:
-    value: ''
-    label: 'Backend Name'
-    description: 'Volume Backend Name'
-    weight: 45
-    type: "text"
   eqlx_group_name:
     value: ''
     label: 'Volume Group Name'


### PR DESCRIPTION
Volume backend name option is a implementaion detail, we can hide it from user.
This remove the volume backend name option on fuel web UI.

issue: http://redmine.eayun.net/issues/3161

Signed-off-by: apporc appleorchard2000@gmail.com
