### PR TITLE
Cancel plugin deployment when $::fuel_settings is empty

### DIFF
--- a/deployment_scripts/site.pp
+++ b/deployment_scripts/site.pp
@@ -1,2 +1,7 @@
 $fuel_settings = parseyaml($astute_settings_yaml)
-class {'plugin_cinder_eqlx': }
+if $fuel_settings {
+  class {'plugin_cinder_eqlx':}
+}
+else {
+  notify {'Empty fuel_settings, plugin deployment canceled.':}
+}


### PR DESCRIPTION
When plugin got an empty $::fuel_settings, at present we think it is because
the deployment on primary_controller has been failed, so we should cancel
deployment.

This may avoid an error in that situation:
"err: ::fuel_settings is not a hash or array when accessing it with role"

Signed-off-by: apporc appleorchard2000@gmail.com
