### PR TITLE
redmine #3238

### DIFF
--- a/deployment_scripts/puppet/plugin_cinder_eqlx/manifests/init.pp
+++ b/deployment_scripts/puppet/plugin_cinder_eqlx/manifests/init.pp
@@ -46,8 +46,8 @@ class plugin_cinder_eqlx
     }
 
     cinder_config {
-      'DEFAULT/ssh_min_pool_conn': value => 1;
-      'DEFAULT/ssh_max_pool_conn': value => 1;
+      'cinder_eqlx/ssh_min_pool_conn': value => 1;
+      'cinder_eqlx/ssh_max_pool_conn': value => 1;
     }
 
     class { 'cinder::backends':
@@ -72,8 +72,8 @@ class plugin_cinder_eqlx
 
     Package[$::cinder::params::package_name] ->
       Cinder::Backend::Eqlx['cinder_eqlx'] ->
-        Cinder_config['DEFAULT/ssh_min_pool_conn'] ->
-          Cinder_config['DEFAULT/ssh_max_pool_conn'] ->
+        Cinder_config['cinder_eqlx/ssh_min_pool_conn'] ->
+          Cinder_config['cinder_eqlx/ssh_max_pool_conn'] ->
             Class['cinder::backends'] ~>
               Service[$::cinder::params::api_service] ~>
                 Service[$::cinder::params::scheduler_service] ~>


### PR DESCRIPTION
https://github.com/eayunstack/fuel-plugin-cinder-eqlx/pull/9 made a mistake about options location.

Move ssh_min_pool_conn and ssh_max_pool_conn options from DEFAULT section to cinder_eqlx now.

Signed-off-by: apporc appleorchard2000@gmail.com
